### PR TITLE
Fix Python dependency for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
+    "preinstall": "apt-get update && apt-get install -y python3 && ln -sf $(command -v python3) /usr/local/bin/python",
     "install": "echo 'Skipping default install step'",
-    "vercel-build": "apt-get update && apt-get install -y python3 && npm install && npm run build"
+    "vercel-build": "npm run build"
   },
   "dependencies": {
     "axios": "^1.7.9",


### PR DESCRIPTION
## Summary
- ensure Python is installed before dependencies by adding a `preinstall` script
- simplify `vercel-build` script

## Testing
- `npm run build`
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688ac85d8540832995c128ba58f7cd9c