### PR TITLE
Fix Python path for Vercel build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "install": "echo 'Skipping default install step'",
-    "vercel-build": "apt-get update && apt-get install -y python3 && npm install && npm run build"
+    "preinstall": "ln -sf $(command -v python3) /usr/local/bin/python || true",
+    "vercel-build": "npm run build"
   },
   "dependencies": {
     "axios": "^1.7.9",


### PR DESCRIPTION
## Summary
- link python3 binary to `python` in preinstall
- remove unused install override

## Testing
- `npm run build`
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_688ac85d8540832995c128ba58f7cd9c