### PR TITLE
Add preinstall script

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,10 @@
   "name": "video_subtitling_mvp",
   "version": "1.0.0",
   "scripts": {
+    "preinstall": "npm config set python python3",
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "preinstall": "apt-get update && apt-get install -y python3 && ln -sf $(command -v python3) /usr/local/bin/python",
     "install": "echo 'Skipping default install step'",
     "vercel-build": "npm run build"
   },


### PR DESCRIPTION
## Summary
- set `npm config set python python3` in `preinstall`

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688acc142d8c83299bf9d1edb3459d79