### PR TITLE
Add Python path for npm

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+python=/usr/bin/python3


### PR DESCRIPTION
## Summary
- tell npm to use python3 by default

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_688acd81c7948329bc8368e9566b95ff